### PR TITLE
Fix VS WebSocket protocol for HTTPS pages

### DIFF
--- a/net.js
+++ b/net.js
@@ -1,10 +1,12 @@
 (function(){
 'use strict';
 
+const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+
 const Net = {
   _tag: '[NET]',
   ws:null,
-  url: (location.hostname ? `ws://${location.hostname}:8080` : 'ws://localhost:8080'),
+  url: (location.hostname ? `${proto}://${location.hostname}:8080` : `${proto}://localhost:8080`),
   roomId:null,
   youId:null,
   seed:null,


### PR DESCRIPTION
## Summary
- Use `wss` when the game is served over HTTPS so 1v1 mode can connect

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_b_6897284284e08320a6307cc28615b684